### PR TITLE
fix activeTextEditor filePath error

### DIFF
--- a/extension/src/providerHelpers/threadProviderHelper.ts
+++ b/extension/src/providerHelpers/threadProviderHelper.ts
@@ -46,7 +46,7 @@ const getActiveEditorFilePath = async () : Promise<string> => {
   const { activeTextEditor } = vscode.window;
 
   if (!activeTextEditor) {
-    return "No active text editor found!";
+    return "";
   }
 
   if (activeTextEditor.document.uri.scheme === 'file'){


### PR DESCRIPTION
# Description 
<!-- Describe the PR in 1-2 sentences. -->
When reloading the vsc it would throw a console error as it couldn't find a git repo for a filePath. It was due to activeTextEditor being an extension output rather than a file. Now it won't throw the console error anymore. User need to click on the active text editor to view the threads. And if the user switches to the extension output then it would show the threads of the latest active filepath. 

# Testing Notes
<!-- Describe briefly how to/what to test in the PR -->

- Reload vsc. 
- Should not see any console errors. 
- Clicking on the activeTextEditor should view the relevant threads. 
- Shouldn't impact thread functionality. 