### PR TITLE
Update order of setting token to storage and closing polka server

### DIFF
--- a/extension/src/providerHelpers/authenticationProviderHelper.ts
+++ b/extension/src/providerHelpers/authenticationProviderHelper.ts
@@ -33,16 +33,17 @@ const getToken = async (req: any, res: any, fn?: () => void) => {
 			return;
 		}
 
+		res.end(`Authentication successful. You can close this now!`);
+		logger.info("Authentication successful.");
+
+		app.server?.close();
+
 		await setTokenToStorage(token);
 
 		if (fn) {
 			fn();
 		}
 
-		res.end(`Authentication successful. You can close this now!`);
-		logger.info("Authentication successful.");
-
-		app.server?.close();
 	} catch (error) {
 		logger.error("An error occured when receiving token" + error);
 	}


### PR DESCRIPTION
# Description 
<!-- Describe the PR in 1-2 sentences. -->
Setting token to secret storage after user has been notified that auth is succesful and polka server is closed. This is will prevent user from waiting on browser if vs code requires Mac password.

# Testing Notes
<!-- Describe briefly how to/what to test in the PR -->

- [ ] Confirmed login is succesful