### PR TITLE
Fix filepath compability issue

### DIFF
--- a/extension/src/providerHelpers/doclinRelativeFilePath.ts
+++ b/extension/src/providerHelpers/doclinRelativeFilePath.ts
@@ -16,10 +16,11 @@ export const getDoclinRelativeFilePath = async (documentUri: vscode.Uri): Promis
 
   if (doclinFilePath) {
     const doclinFolder = path.dirname(doclinFilePath.fsPath);
-    const doclinRelativePath = path.relative(doclinFolder, activeEditorFilePath);
+    const normalizedDoclinFolder = doclinFolder.split(path.sep).join(path.posix.sep);
+    const normalizedActiveEditorFilePath = activeEditorFilePath.split(path.sep).join(path.posix.sep);
+    const doclinRelativePath = path.posix.relative(normalizedDoclinFolder, normalizedActiveEditorFilePath);
 
     await doclinRelativePathCacheManager.set(activeEditorFilePath, doclinRelativePath);
-
     return doclinRelativePath;
   }
 

--- a/extension/src/providerHelpers/doclinRelativeFilePath.ts
+++ b/extension/src/providerHelpers/doclinRelativeFilePath.ts
@@ -6,19 +6,19 @@ import DoclinRelativePathCacheManager from '../utils/cache/DoclinRelativePathCac
 export const getDoclinRelativeFilePath = async (documentUri: vscode.Uri): Promise<string> => {
   const activeEditorFilePath: string = documentUri.fsPath;
   const doclinRelativePathCacheManager = new DoclinRelativePathCacheManager();
-  const cachedRelativePath = await doclinRelativePathCacheManager.get(activeEditorFilePath);
+  const cachedRelativePath: string | undefined = await doclinRelativePathCacheManager.get(activeEditorFilePath);
 
   if (cachedRelativePath) {
     return cachedRelativePath;
   }
 
-  const doclinFilePath = await getExistingDoclinFile();
+  const doclinFilePath: vscode.Uri | null = await getExistingDoclinFile();
 
   if (doclinFilePath) {
-    const doclinFolder = path.dirname(doclinFilePath.fsPath);
-    const normalizedDoclinFolder = doclinFolder.split(path.sep).join(path.posix.sep);
-    const normalizedActiveEditorFilePath = activeEditorFilePath.split(path.sep).join(path.posix.sep);
-    const doclinRelativePath = path.posix.relative(normalizedDoclinFolder, normalizedActiveEditorFilePath);
+    const doclinFolder: string = path.dirname(doclinFilePath.fsPath);
+    const normalizedDoclinFolder: string = doclinFolder.split(path.sep).join(path.posix.sep);
+    const normalizedActiveEditorFilePath: string = activeEditorFilePath.split(path.sep).join(path.posix.sep);
+    const doclinRelativePath: string = path.posix.relative(normalizedDoclinFolder, normalizedActiveEditorFilePath);
 
     await doclinRelativePathCacheManager.set(activeEditorFilePath, doclinRelativePath);
     return doclinRelativePath;


### PR DESCRIPTION
Description
-----------------------------
_Describe in detail what your pull request does and why._

Windows is using backward slash. Unix-like is using forward slash.

So when a thread is created on Windows, it is showing as outdated or Unix systems. And vice-versa.

Screenshots or screen recordings
-----------------------------
- Attach screenshots/screen recordings where applicable. Highly recommended for all the changes.
- Include before and after images, this will assist reviewers and future readers in understanding the change better.



How to test the change
-----------------------------
_Outline the steps to set up and validate the change._

- [x] Create thread with snippet on windows. Ensure the filepath uses forward slash.
- [x] Create thread with snippet on Mac. Ensure the filepath uses forward slash.
- [x] Reload and smoke test threads loading/creation/update.

-----------------------------
_Check this if your PR is ready to merge and a reviewer will merge when approved._

- [x] Ready to merge