### PR TITLE
Add anonymous posting feature to thread notification

### DIFF
--- a/api/src/controllers/emailNotificationController.ts
+++ b/api/src/controllers/emailNotificationController.ts
@@ -7,7 +7,7 @@ import logger from '../logger';
 const SENDER_EMAIL: string = 'noreply@doclin.dev';
 const SENDER_NAME: string = 'Doclin';
 const MENTION_EMAIL_SUBJECT = 'has mentioned you in doclin.';
-const ANONYMOUS_USER='Anonymous User'
+const ANONYMOUS_USER = 'Anonymous User';
 export const sendEmailFromDoclin = (recipientEmails: string[], subject: string, message: string, sender?: string) => {
   if (!SENDGRID_API_KEY) {
     throw new Error('Sendgrid API key not set');
@@ -37,12 +37,11 @@ export const sendEmailFromDoclin = (recipientEmails: string[], subject: string, 
 };
 
 export const sendMentionEmailNotification = async (
-
   senderId: number,
   targetUserIds: number[],
   projectId: number,
   message: string,
-  anonymous: boolean=false,
+  anonymous: boolean = false
 ) => {
   let senderName: string | undefined = ANONYMOUS_USER;
   if (!anonymous) {

--- a/api/src/controllers/emailNotificationController.ts
+++ b/api/src/controllers/emailNotificationController.ts
@@ -7,7 +7,7 @@ import logger from '../logger';
 const SENDER_EMAIL: string = 'noreply@doclin.dev';
 const SENDER_NAME: string = 'Doclin';
 const MENTION_EMAIL_SUBJECT = 'has mentioned you in doclin.';
-
+const ANONYMOUS_USER='Anonymous User'
 export const sendEmailFromDoclin = (recipientEmails: string[], subject: string, message: string, sender?: string) => {
   if (!SENDGRID_API_KEY) {
     throw new Error('Sendgrid API key not set');
@@ -37,20 +37,18 @@ export const sendEmailFromDoclin = (recipientEmails: string[], subject: string, 
 };
 
 export const sendMentionEmailNotification = async (
-  anonymous:boolean,
+
   senderId: number,
   targetUserIds: number[],
   projectId: number,
-  message: string
+  message: string,
+  anonymous: boolean=false,
 ) => {
-  
-  let senderName:string|undefined ="Anonymous User"
-  if(!anonymous){
-
+  let senderName: string | undefined = ANONYMOUS_USER;
+  if (!anonymous) {
     const sender = await UserRepository.findUserById(senderId);
     senderName = sender?.name;
   }
-
 
   const targetUsers = targetUserIds.map(async (mentionedUserId) => {
     const user = await UserRepository.findUserById(mentionedUserId);
@@ -65,7 +63,6 @@ export const sendMentionEmailNotification = async (
   const emailSubject = `${senderName} ${MENTION_EMAIL_SUBJECT}`;
   const emailMessage = `${senderName} has mentioned you on a thread in project ${projectName}. 
 					${message}`;
-
 
   sendEmailFromDoclin(targetUserEmails, emailSubject, emailMessage, senderName);
 };

--- a/api/src/controllers/emailNotificationController.ts
+++ b/api/src/controllers/emailNotificationController.ts
@@ -37,13 +37,21 @@ export const sendEmailFromDoclin = (recipientEmails: string[], subject: string, 
 };
 
 export const sendMentionEmailNotification = async (
+  anonymous:boolean,
   senderId: number,
   targetUserIds: number[],
   projectId: number,
   message: string
 ) => {
-  const sender = await UserRepository.findUserById(senderId);
-  const senderName = sender?.name;
+  
+  let senderName:string|undefined ="Anonymous User"
+  if(!anonymous){
+
+    const sender = await UserRepository.findUserById(senderId);
+    senderName = sender?.name;
+  }
+
+
   const targetUsers = targetUserIds.map(async (mentionedUserId) => {
     const user = await UserRepository.findUserById(mentionedUserId);
     return user ? user.email : null;
@@ -57,6 +65,7 @@ export const sendMentionEmailNotification = async (
   const emailSubject = `${senderName} ${MENTION_EMAIL_SUBJECT}`;
   const emailMessage = `${senderName} has mentioned you on a thread in project ${projectName}. 
 					${message}`;
+
 
   sendEmailFromDoclin(targetUserEmails, emailSubject, emailMessage, senderName);
 };

--- a/api/src/controllers/threadController.ts
+++ b/api/src/controllers/threadController.ts
@@ -48,6 +48,7 @@ export const postThread = async (req: Request, res: Response) => {
 
   if (mentionedUserIds.length > 0) {
     sendMentionEmailNotification(
+      anonymousPost,
       req.userId,
       mentionedUserIds,
       projectId,

--- a/api/src/controllers/threadController.ts
+++ b/api/src/controllers/threadController.ts
@@ -52,7 +52,7 @@ export const postThread = async (req: Request, res: Response) => {
       mentionedUserIds,
       projectId,
       fillUpThreadOrReplyMessageWithSnippet(threadMessage, snippets),
-      anonymousPost,
+      anonymousPost
     );
   }
 

--- a/api/src/controllers/threadController.ts
+++ b/api/src/controllers/threadController.ts
@@ -48,11 +48,11 @@ export const postThread = async (req: Request, res: Response) => {
 
   if (mentionedUserIds.length > 0) {
     sendMentionEmailNotification(
-      anonymousPost,
       req.userId,
       mentionedUserIds,
       projectId,
-      fillUpThreadOrReplyMessageWithSnippet(threadMessage, snippets)
+      fillUpThreadOrReplyMessageWithSnippet(threadMessage, snippets),
+      anonymousPost,
     );
   }
 


### PR DESCRIPTION
Description
-----------------------------
This pull request addresses the issue of revealing the thread creator's name in email notifications when the thread is posted anonymously. The following changes were made:

 Added an `anonymous` parameter to the `sendMentionEmailNotification` function.
- Modified the `postThread` function to pass the `anonymous` parameter.
- Updated email subject and message to reflect anonymous posting.

### Checklist

- Succesfully run all the tests provided in the contributing.md file
